### PR TITLE
Added forward ref support

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,20 @@
-import React, { lazy, Suspense } from 'react';
+import React, { Suspense, forwardRef, lazy } from "react";
 
-const loadable = (importFunc, { fallback = null } = { fallback: null }) => {
+const loadable = (
+  importFunc,
+  { fallback = null, withForwardRef = false } = { fallback: null }
+) => {
   const LazyComponent = lazy(importFunc);
 
+  if (withForwardRef) {
+    return forwardRef((innerProps, ref) => (
+      <Suspense fallback={fallback}>
+        <LazyComponent {...innerProps} ref={ref} />
+      </Suspense>
+    ));
+  }
+
+  // Regular case: return a function
   return (props) => (
     <Suspense fallback={fallback}>
       <LazyComponent {...props} />


### PR DESCRIPTION
Normal usage: 
loadable(() => import('./index'));

Usage with forward ref:
loadable(() => import('./index'), { withForwardRef: true });

Example code with forward ref:
// index.ts

import { forwardRef, useMemo } from 'react';
import React from 'react';
import loadable from 'react-suspense-loadable';

const Input = forwardRef((props: any, ref: React.ForwardedRef<any>) => {
  const Comp = loadable(() => import('./mui/index'), { withForwardRef: true });

  if (Comp) {
    return <Comp {...props} ref={ref} />;
  }
  return null;
});

export default Input;
